### PR TITLE
fix: ensure PRs are added to project with correct status

### DIFF
--- a/.github/workflows/add-pr-to-project.yml
+++ b/.github/workflows/add-pr-to-project.yml
@@ -1,0 +1,75 @@
+name: Add PR to Project
+
+on:
+  pull_request:
+    types: [opened, reopened]
+
+permissions:
+  pull-requests: read
+  repository-projects: write
+
+jobs:
+  add-to-project:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Add PR to Project
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const pr = context.payload.pull_request;
+            console.log(`Adding PR #${pr.number} to project`);
+
+            // GraphQL to add PR to project
+            const addToProjectMutation = `
+              mutation($projectId: ID!, $contentId: ID!) {
+                addProjectV2ItemById(input: {projectId: $projectId, contentId: $contentId}) {
+                  item {
+                    id
+                  }
+                }
+              }
+            `;
+
+            // First, get the project ID
+            const projectQuery = `
+              query($owner: String!, $number: Int!) {
+                user(login: $owner) {
+                  projectV2(number: $number) {
+                    id
+                  }
+                }
+              }
+            `;
+
+            try {
+              // Get project ID (Project #1)
+              const projectData = await github.graphql(projectQuery, {
+                owner: context.repo.owner,
+                number: 1
+              });
+
+              const projectId = projectData.user.projectV2.id;
+              console.log(`Found project ID: ${projectId}`);
+
+              // Add PR to project
+              const result = await github.graphql(addToProjectMutation, {
+                projectId: projectId,
+                contentId: pr.node_id
+              });
+
+              console.log(`✅ Successfully added PR #${pr.number} to project`);
+
+              // The auto-set-pr-status workflow will handle setting the initial status label
+              // The sync-labels-to-project workflow will then sync that label to the project field
+
+            } catch (error) {
+              console.error('Failed to add PR to project:', error.message);
+              
+              // If it fails because it's already in the project, that's fine
+              if (error.message.includes('already exists')) {
+                console.log('PR already in project');
+              } else {
+                throw error;
+              }
+            }

--- a/.github/workflows/sync-labels-to-project.yml
+++ b/.github/workflows/sync-labels-to-project.yml
@@ -3,11 +3,14 @@ name: Sync Issue Labels to Project Fields
 on:
   issues:
     types: [opened, labeled, unlabeled]
+  pull_request:
+    types: [opened, labeled, unlabeled]
   project_card:
     types: [created, moved]
 
 permissions:
   issues: read
+  pull-requests: read
   repository-projects: write
 
 jobs:
@@ -19,9 +22,16 @@ jobs:
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
-            const issueNumber = context.issue?.number || context.payload.issue?.number;
+            // Get issue/PR number from different event contexts
+            let issueNumber;
+            if (context.eventName === 'pull_request') {
+              issueNumber = context.payload.pull_request?.number;
+            } else {
+              issueNumber = context.issue?.number || context.payload.issue?.number;
+            }
+
             if (!issueNumber) {
-              console.log('No issue number found');
+              console.log('No issue/PR number found');
               return;
             }
 

--- a/scripts/fix-pr-project-status.js
+++ b/scripts/fix-pr-project-status.js
@@ -1,0 +1,76 @@
+#!/usr/bin/env node
+
+/**
+ * Script to fix PR project status for existing PRs
+ * This ensures all PRs in the project have the correct status based on their state
+ */
+
+const { execSync } = require("child_process");
+
+async function fixPRProjectStatus() {
+  console.log("🔧 Fixing PR project status...\n");
+
+  try {
+    // Get all open PRs
+    const prsJson = execSync(
+      `gh pr list --json number,isDraft,state --limit 100`,
+      { encoding: "utf8" }
+    );
+    const prs = JSON.parse(prsJson);
+
+    console.log(`Found ${prs.length} open PRs\n`);
+
+    for (const pr of prs) {
+      console.log(`\nProcessing PR #${pr.number}...`);
+
+      // Get current labels
+      const labelsJson = execSync(
+        `gh pr view ${pr.number} --json labels`,
+        { encoding: "utf8" }
+      );
+      const { labels } = JSON.parse(labelsJson);
+      const labelNames = labels.map(l => l.name);
+
+      // Remove existing status labels
+      const statusLabels = labelNames.filter(l => l.startsWith('status:'));
+      for (const label of statusLabels) {
+        console.log(`  Removing label: ${label}`);
+        execSync(`gh pr edit ${pr.number} --remove-label "${label}"`, { stdio: 'pipe' });
+      }
+
+      // Add appropriate status label
+      let newStatus;
+      if (pr.isDraft) {
+        newStatus = 'status: pr-in-progress';
+      } else {
+        // Check if it has approvals
+        const reviewsJson = execSync(
+          `gh pr view ${pr.number} --json reviews`,
+          { encoding: "utf8" }
+        );
+        const { reviews } = JSON.parse(reviewsJson);
+        const hasApproval = reviews.some(r => r.state === 'APPROVED');
+
+        if (hasApproval) {
+          newStatus = 'status: code-review-complete';
+        } else {
+          newStatus = 'status: in-code-review';
+        }
+      }
+
+      console.log(`  Adding label: ${newStatus}`);
+      execSync(`gh pr edit ${pr.number} --add-label "${newStatus}"`, { stdio: 'pipe' });
+
+      console.log(`  ✅ Fixed PR #${pr.number}`);
+    }
+
+    console.log("\n✅ All PRs have been updated!");
+    console.log("\nThe sync-labels-to-project workflow will now sync these labels to the project fields.");
+
+  } catch (error) {
+    console.error("❌ Error:", error.message);
+    process.exit(1);
+  }
+}
+
+fixPRProjectStatus();


### PR DESCRIPTION
## Summary

This PR fixes the issue where new PRs were showing as "No Status" in the GitHub Project board instead of being automatically set to "PR in Progress" or "In Code Review".

## Problem

The existing automation had two issues:
1. PRs weren't being automatically added to the project when created
2. The label sync workflow only listened to `issues` events, not `pull_request` events

## Solution

1. **Updated `sync-labels-to-project.yml`**:
   - Now listens to `pull_request` events in addition to `issues` events
   - Handles both issue and PR contexts when syncing labels to project fields

2. **Added `add-pr-to-project.yml`**:
   - Automatically adds new PRs to the project when they're opened or reopened
   - Works in conjunction with existing workflows that set status labels

3. **Created `scripts/fix-pr-project-status.js`**:
   - Utility script to fix existing PRs that have "No Status"
   - Sets appropriate status labels based on PR state (draft, review status, etc.)

## How it works

1. When a PR is opened:
   - `add-pr-to-project.yml` adds it to the project
   - `auto-set-pr-status.yml` sets the appropriate status label
   - `sync-labels-to-project.yml` syncs the label to the project field

2. For existing PRs:
   - Run `node scripts/fix-pr-project-status.js` to fix their status

## Testing

- This PR itself should be automatically added to the project with "In Code Review" status
- Future PRs will be properly tracked from creation

Fixes the issue shown in the screenshot where recent PRs had "No Status".

🤖 Generated with [Claude Code](https://claude.ai/code)