### PR TITLE
fix: disable old preview workflow to prevent duplicate deployments

### DIFF
--- a/.github/workflows/deploy-demo-preview.yml
+++ b/.github/workflows/deploy-demo-preview.yml
@@ -1,4 +1,6 @@
-name: Deploy Demo Preview
+name: Deploy Demo Preview (Disabled)
+# DISABLED: This workflow has been replaced by deploy-demo-preview-smart.yml
+# To re-enable, remove the if: false condition from the deploy-preview job
 
 on:
   pull_request:
@@ -18,7 +20,8 @@ jobs:
   deploy-preview:
     name: Deploy PR Preview
     runs-on: ubuntu-latest
-    if: github.event.pull_request.head.repo.full_name == github.repository
+    # DISABLED: This workflow is replaced by smart preview deployment
+    if: false
 
     steps:
       - name: Checkout code


### PR DESCRIPTION
Quick fix to disable the old preview deployment workflow to prevent confusion and duplicate deployments while we transition to the smart preview system.

- Adds `if: false` condition to prevent the old workflow from running
- PR #38's smart workflow correctly skipped deployment (workflow-only changes)
- The old workflow incorrectly deployed because it still includes workflow paths

Once this is merged, only the smart preview workflow will be active.