### PR TITLE
fix: correct project workflow issues blocking PR merges

### DIFF
--- a/.github/workflows/add-pr-to-project.yml
+++ b/.github/workflows/add-pr-to-project.yml
@@ -1,0 +1,75 @@
+name: Add PR to Project
+
+on:
+  pull_request:
+    types: [opened, reopened]
+
+permissions:
+  pull-requests: read
+  repository-projects: write
+
+jobs:
+  add-to-project:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Add PR to Project
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const pr = context.payload.pull_request;
+            console.log(`Adding PR #${pr.number} to project`);
+
+            // GraphQL to add PR to project
+            const addToProjectMutation = `
+              mutation($projectId: ID!, $contentId: ID!) {
+                addProjectV2ItemById(input: {projectId: $projectId, contentId: $contentId}) {
+                  item {
+                    id
+                  }
+                }
+              }
+            `;
+
+            // First, get the project ID
+            const projectQuery = `
+              query($owner: String!, $number: Int!) {
+                user(login: $owner) {
+                  projectV2(number: $number) {
+                    id
+                  }
+                }
+              }
+            `;
+
+            try {
+              // Get project ID (Project #1)
+              const projectData = await github.graphql(projectQuery, {
+                owner: context.repo.owner,
+                number: 1
+              });
+
+              const projectId = projectData.user.projectV2.id;
+              console.log(`Found project ID: ${projectId}`);
+
+              // Add PR to project
+              const result = await github.graphql(addToProjectMutation, {
+                projectId: projectId,
+                contentId: pr.node_id
+              });
+
+              console.log(`✅ Successfully added PR #${pr.number} to project`);
+
+              // The auto-set-pr-status workflow will handle setting the initial status label
+              // The sync-labels-to-project workflow will then sync that label to the project field
+
+            } catch (error) {
+              console.error('Failed to add PR to project:', error.message);
+              
+              // If it fails because it's already in the project, that's fine
+              if (error.message.includes('already exists')) {
+                console.log('PR already in project');
+              } else {
+                throw error;
+              }
+            }

--- a/.github/workflows/add-pr-to-project.yml
+++ b/.github/workflows/add-pr-to-project.yml
@@ -31,25 +31,12 @@ jobs:
               }
             `;
 
-            // First, get the project ID
-            const projectQuery = `
-              query($owner: String!, $number: Int!) {
-                user(login: $owner) {
-                  projectV2(number: $number) {
-                    id
-                  }
-                }
-              }
-            `;
+            // Get the project ID directly using its node ID
+            // This is the AG Grid React Components Roadmap project
+            // You can find this ID by querying the project or from the project URL
+            const projectId = 'PVT_kwHOBMT9Es4Aqh-F'; // AG Grid React Components Roadmap
 
             try {
-              // Get project ID (Project #1)
-              const projectData = await github.graphql(projectQuery, {
-                owner: context.repo.owner,
-                number: 1
-              });
-
-              const projectId = projectData.user.projectV2.id;
               console.log(`Found project ID: ${projectId}`);
 
               // Add PR to project

--- a/.github/workflows/deploy-demo-preview-smart.yml
+++ b/.github/workflows/deploy-demo-preview-smart.yml
@@ -1,26 +1,81 @@
-name: Deploy Demo Preview
-# DEPRECATED: This workflow is being replaced by deploy-demo-preview-smart.yml
-# which provides more intelligent deployment decisions
+name: Smart Demo Preview Deployment
 
 on:
   pull_request:
-    types: [opened, synchronize]
+    types: [opened, synchronize, labeled]
     paths:
-      - "src/**"
+      # Component source code
+      - "src/components/**"
+      - "src/utils/**"
+      - "src/index.ts"
+
+      # Demo application
+      - "src/demo/**"
       - "public/**"
+
+      # Configuration that affects the demo
       - "package.json"
       - "vite.config.demo.ts"
-      - ".github/workflows/deploy-demo-preview.yml"
+      - "tsconfig.json"
+
+      # API changes
+      - "api/**"
+
+      # This workflow
+      - ".github/workflows/deploy-demo-preview-smart.yml"
 
 permissions:
   pull-requests: write
   contents: read
+  issues: write
 
 jobs:
+  check-preview-needed:
+    name: Check if Preview Needed
+    runs-on: ubuntu-latest
+    outputs:
+      should-deploy: ${{ steps.check.outputs.should-deploy }}
+      reason: ${{ steps.check.outputs.reason }}
+
+    steps:
+      - name: Check deployment criteria
+        id: check
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const pr = context.payload.pull_request;
+            const labels = pr.labels.map(l => l.name);
+
+            // Force deployment if labeled
+            if (labels.includes('deploy-preview')) {
+              core.setOutput('should-deploy', 'true');
+              core.setOutput('reason', 'Manual override via deploy-preview label');
+              return;
+            }
+
+            // Skip if labeled
+            if (labels.includes('skip-preview')) {
+              core.setOutput('should-deploy', 'false');
+              core.setOutput('reason', 'Skipped via skip-preview label');
+              return;
+            }
+
+            // Check if it's from a fork
+            if (pr.head.repo.full_name !== context.repo.full_name) {
+              core.setOutput('should-deploy', 'false');
+              core.setOutput('reason', 'PRs from forks cannot be auto-deployed');
+              return;
+            }
+
+            // Default: deploy based on path filters (already handled by workflow paths)
+            core.setOutput('should-deploy', 'true');
+            core.setOutput('reason', 'Contains changes to demo-relevant files');
+
   deploy-preview:
     name: Deploy PR Preview
+    needs: check-preview-needed
+    if: needs.check-preview-needed.outputs.should-deploy == 'true'
     runs-on: ubuntu-latest
-    if: github.event.pull_request.head.repo.full_name == github.repository
 
     steps:
       - name: Checkout code
@@ -124,6 +179,22 @@ jobs:
 
           # Run deployment tests
           DEMO_URL="$DEMO_URL" npx playwright test tests/e2e/demo-deployment.spec.ts --reporter=list
+
+      - name: Add preview label
+        uses: actions/github-script@v7
+        with:
+          script: |
+            try {
+              await github.rest.issues.addLabels({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.payload.pull_request.number,
+                labels: ['has-preview']
+              });
+            } catch (e) {
+              console.log('Could not add label:', e.message);
+            }
+
       - name: Comment on PR
         uses: actions/github-script@v7
         with:
@@ -140,7 +211,65 @@ jobs:
 
             This preview will be available for testing until the PR is merged or closed.`;
 
-            github.rest.issues.createComment({
+            // Check if we already commented
+            const comments = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: prNumber
+            });
+
+            const botComment = comments.data.find(comment => 
+              comment.user.type === 'Bot' && 
+              comment.body.includes('Demo Preview Ready!')
+            );
+
+            if (botComment) {
+              // Update existing comment
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: botComment.id,
+                body: comment
+              });
+            } else {
+              // Create new comment
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: prNumber,
+                body: comment
+              });
+            }
+
+  skip-notification:
+    name: Notify Skip Reason
+    needs: check-preview-needed
+    if: needs.check-preview-needed.outputs.should-deploy == 'false'
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Comment skip reason
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const reason = '${{ needs.check-preview-needed.outputs.reason }}';
+            const prNumber = context.payload.pull_request.number;
+
+            // Only comment if this is a new PR or if skip-preview was just added
+            const eventAction = context.payload.action;
+            if (eventAction !== 'opened' && eventAction !== 'labeled') {
+              return;
+            }
+
+            const comment = `ℹ️ **Demo Preview Skipped**
+
+            ${reason}
+
+            To deploy a preview for this PR, you can:
+            - Add the \`deploy-preview\` label to force deployment
+            - Make changes to demo-relevant files (components, demo app, etc.)`;
+
+            await github.rest.issues.createComment({
               owner: context.repo.owner,
               repo: context.repo.repo,
               issue_number: prNumber,

--- a/.github/workflows/deploy-demo-preview-smart.yml
+++ b/.github/workflows/deploy-demo-preview-smart.yml
@@ -61,7 +61,10 @@ jobs:
             }
 
             // Check if it's from a fork
-            if (pr.head.repo.full_name !== context.repo.full_name) {
+            const prRepoFullName = pr.head.repo?.full_name || '';
+            const currentRepoFullName = `${context.repo.owner}/${context.repo.repo}`;
+
+            if (prRepoFullName !== currentRepoFullName) {
               core.setOutput('should-deploy', 'false');
               core.setOutput('reason', 'PRs from forks cannot be auto-deployed');
               return;
@@ -255,9 +258,10 @@ jobs:
             const reason = '${{ needs.check-preview-needed.outputs.reason }}';
             const prNumber = context.payload.pull_request.number;
 
-            // Only comment if this is a new PR or if skip-preview was just added
+            // Only comment if this is a new PR
             const eventAction = context.payload.action;
-            if (eventAction !== 'opened' && eventAction !== 'labeled') {
+            if (eventAction !== 'opened') {
+              console.log(`Skipping comment - action is ${eventAction}, not 'opened'`);
               return;
             }
 

--- a/.github/workflows/manual-preview-control.yml
+++ b/.github/workflows/manual-preview-control.yml
@@ -1,0 +1,130 @@
+name: Manual Preview Control
+
+on:
+  issue_comment:
+    types: [created]
+
+permissions:
+  pull-requests: write
+  contents: read
+  issues: write
+
+jobs:
+  handle-preview-command:
+    if: |
+      github.event.issue.pull_request && 
+      (contains(github.event.comment.body, '/preview') || contains(github.event.comment.body, '/skip-preview'))
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check commenter permissions
+        id: check-permissions
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const commenter = context.payload.comment.user.login;
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+
+            try {
+              const { data: permissionLevel } = await github.rest.repos.getCollaboratorPermissionLevel({
+                owner,
+                repo,
+                username: commenter
+              });
+              
+              if (['admin', 'write'].includes(permissionLevel.permission)) {
+                core.setOutput('has-permission', 'true');
+              } else {
+                core.setOutput('has-permission', 'false');
+              }
+            } catch (e) {
+              core.setOutput('has-permission', 'false');
+            }
+
+      - name: Handle preview command
+        if: steps.check-permissions.outputs.has-permission == 'true'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const comment = context.payload.comment.body.toLowerCase();
+            const issueNumber = context.issue.number;
+
+            // React to the comment
+            await github.rest.reactions.createForIssueComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              comment_id: context.payload.comment.id,
+              content: 'rocket'
+            });
+
+            if (comment.includes('/preview')) {
+              // Add deploy-preview label
+              await github.rest.issues.addLabels({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: issueNumber,
+                labels: ['deploy-preview']
+              });
+              
+              // Remove skip-preview if present
+              try {
+                await github.rest.issues.removeLabel({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: issueNumber,
+                  name: 'skip-preview'
+                });
+              } catch (e) {}
+              
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: issueNumber,
+                body: '🚀 Preview deployment triggered! The preview will be ready in a few minutes.'
+              });
+              
+            } else if (comment.includes('/skip-preview')) {
+              // Add skip-preview label
+              await github.rest.issues.addLabels({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: issueNumber,
+                labels: ['skip-preview']
+              });
+              
+              // Remove deploy-preview if present
+              try {
+                await github.rest.issues.removeLabel({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: issueNumber,
+                  name: 'deploy-preview'
+                });
+              } catch (e) {}
+              
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: issueNumber,
+                body: '⏭️ Preview deployment skipped. Use `/preview` to deploy if needed later.'
+              });
+            }
+
+      - name: Handle no permission
+        if: steps.check-permissions.outputs.has-permission == 'false'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            await github.rest.reactions.createForIssueComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              comment_id: context.payload.comment.id,
+              content: '-1'
+            });
+
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              body: '❌ Sorry, you need write permissions to control preview deployments.'
+            });

--- a/.github/workflows/sync-labels-to-project.yml
+++ b/.github/workflows/sync-labels-to-project.yml
@@ -114,10 +114,12 @@ jobs:
             console.log('Field updates to apply:', fieldUpdates);
 
             // GraphQL to find the project and update fields
+            // Note: PRs are accessed via pullRequest, not issue in GraphQL
+            const isPR = context.eventName === 'pull_request';
             const projectQuery = `
-              query($owner: String!, $repo: String!, $issue: Int!) {
+              query($owner: String!, $repo: String!, $number: Int!) {
                 repository(owner: $owner, name: $repo) {
-                  issue(number: $issue) {
+                  ${isPR ? 'pullRequest' : 'issue'}(number: $number) {
                     projectItems(first: 10) {
                       nodes {
                         id
@@ -151,10 +153,11 @@ jobs:
             const projectData = await github.graphql(projectQuery, {
               owner: context.repo.owner,
               repo: context.repo.repo,
-              issue: issueNumber
+              number: issueNumber
             });
 
-            const projectItems = projectData.repository.issue.projectItems.nodes;
+            const issueOrPR = isPR ? projectData.repository.pullRequest : projectData.repository.issue;
+            const projectItems = issueOrPR?.projectItems?.nodes || [];
             if (projectItems.length === 0) {
               console.log('Issue not found in any project');
               return;

--- a/.github/workflows/sync-labels-to-project.yml
+++ b/.github/workflows/sync-labels-to-project.yml
@@ -3,11 +3,14 @@ name: Sync Issue Labels to Project Fields
 on:
   issues:
     types: [opened, labeled, unlabeled]
+  pull_request:
+    types: [opened, labeled, unlabeled]
   project_card:
     types: [created, moved]
 
 permissions:
   issues: read
+  pull-requests: read
   repository-projects: write
 
 jobs:
@@ -19,9 +22,16 @@ jobs:
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
-            const issueNumber = context.issue?.number || context.payload.issue?.number;
+            // Get issue/PR number from different event contexts
+            let issueNumber;
+            if (context.eventName === 'pull_request') {
+              issueNumber = context.payload.pull_request?.number;
+            } else {
+              issueNumber = context.issue?.number || context.payload.issue?.number;
+            }
+
             if (!issueNumber) {
-              console.log('No issue number found');
+              console.log('No issue/PR number found');
               return;
             }
 

--- a/docs/smart-pr-previews.md
+++ b/docs/smart-pr-previews.md
@@ -1,0 +1,84 @@
+# Smart PR Preview Deployments
+
+This project uses intelligent PR preview deployments that only deploy when necessary, saving resources and reducing noise.
+
+## How It Works
+
+### Automatic Deployment
+
+PR previews are automatically deployed when changes are made to:
+
+- **Component source code** (`src/components/**`, `src/utils/**`)
+- **Demo application** (`src/demo/**`)
+- **Public assets** (`public/**`)
+- **Configuration files** that affect the demo (`package.json`, `vite.config.demo.ts`, `tsconfig.json`)
+- **API code** (`api/**`)
+
+### Skipped Deployments
+
+Previews are NOT deployed for changes to:
+
+- GitHub Actions workflows (`.github/**`)
+- Documentation (`*.md`, `docs/**`)
+- Tests (`tests/**`, `*.test.ts`)
+- Scripts (`scripts/**`)
+- Build tools and configs (except those listed above)
+- Other non-demo files
+
+## Manual Control
+
+### Using Labels
+
+- **`deploy-preview`** - Forces a preview deployment even if changes don't normally trigger one
+- **`skip-preview`** - Prevents preview deployment even if changes would normally trigger one
+- **`has-preview`** - Automatically added when a preview is deployed (do not add manually)
+
+### Using Comments
+
+You can control preview deployments by commenting on a PR:
+
+- **`/preview`** - Triggers a preview deployment
+- **`/skip-preview`** - Skips preview deployment
+
+Only users with write permissions can use these commands.
+
+## Examples
+
+### PR with only workflow changes
+
+```yaml
+# Changes to .github/workflows/ci.yml
+# Result: No preview deployed
+# Message: "Demo Preview Skipped - Contains no demo-relevant changes"
+```
+
+### PR with component changes
+
+```typescript
+// Changes to src/components/DateFilter/index.tsx
+// Result: Preview automatically deployed
+// Message: "Demo Preview Ready!"
+```
+
+### Forcing a preview
+
+```bash
+# Comment on PR: /preview
+# Result: Preview deployed regardless of changes
+# Label added: deploy-preview
+```
+
+## Benefits
+
+1. **Faster CI** - Skips unnecessary builds and deployments
+2. **Cost savings** - Reduces Cloudflare R2 storage and Worker invocations
+3. **Cleaner PR threads** - Only relevant PRs get preview comments
+4. **Manual override** - Can still force previews when needed
+
+## Migration
+
+The new smart preview system replaces the old `deploy-demo-preview.yml` workflow. To migrate:
+
+1. The old workflow still works but should be considered deprecated
+2. New PRs will automatically use the smart system
+3. Existing PRs can be controlled with labels or comments

--- a/scripts/create-preview-labels.js
+++ b/scripts/create-preview-labels.js
@@ -1,0 +1,55 @@
+#!/usr/bin/env node
+
+/**
+ * Script to create labels used by the smart preview deployment system
+ */
+
+const { execSync } = require("child_process");
+
+const labels = [
+  {
+    name: "deploy-preview",
+    description: "Force deployment of PR preview",
+    color: "0E8A16"  // Green
+  },
+  {
+    name: "skip-preview",
+    description: "Skip PR preview deployment",
+    color: "FBCA04"  // Yellow
+  },
+  {
+    name: "has-preview",
+    description: "PR has a deployed preview",
+    color: "1D76DB"  // Blue
+  }
+];
+
+async function createLabels() {
+  console.log("🏷️  Creating smart preview deployment labels...\n");
+
+  for (const label of labels) {
+    try {
+      // Check if label exists
+      try {
+        execSync(`gh label view "${label.name}"`, { stdio: 'pipe' });
+        console.log(`✓ Label "${label.name}" already exists`);
+        continue;
+      } catch (e) {
+        // Label doesn't exist, create it
+      }
+
+      // Create label
+      execSync(
+        `gh label create "${label.name}" --description "${label.description}" --color "${label.color}"`,
+        { stdio: 'inherit' }
+      );
+      console.log(`✅ Created label "${label.name}"`);
+    } catch (error) {
+      console.error(`❌ Failed to create label "${label.name}":`, error.message);
+    }
+  }
+
+  console.log("\n✅ All labels processed!");
+}
+
+createLabels();

--- a/scripts/fix-pr-project-status.js
+++ b/scripts/fix-pr-project-status.js
@@ -1,0 +1,76 @@
+#!/usr/bin/env node
+
+/**
+ * Script to fix PR project status for existing PRs
+ * This ensures all PRs in the project have the correct status based on their state
+ */
+
+const { execSync } = require("child_process");
+
+async function fixPRProjectStatus() {
+  console.log("🔧 Fixing PR project status...\n");
+
+  try {
+    // Get all open PRs
+    const prsJson = execSync(
+      `gh pr list --json number,isDraft,state --limit 100`,
+      { encoding: "utf8" }
+    );
+    const prs = JSON.parse(prsJson);
+
+    console.log(`Found ${prs.length} open PRs\n`);
+
+    for (const pr of prs) {
+      console.log(`\nProcessing PR #${pr.number}...`);
+
+      // Get current labels
+      const labelsJson = execSync(
+        `gh pr view ${pr.number} --json labels`,
+        { encoding: "utf8" }
+      );
+      const { labels } = JSON.parse(labelsJson);
+      const labelNames = labels.map(l => l.name);
+
+      // Remove existing status labels
+      const statusLabels = labelNames.filter(l => l.startsWith('status:'));
+      for (const label of statusLabels) {
+        console.log(`  Removing label: ${label}`);
+        execSync(`gh pr edit ${pr.number} --remove-label "${label}"`, { stdio: 'pipe' });
+      }
+
+      // Add appropriate status label
+      let newStatus;
+      if (pr.isDraft) {
+        newStatus = 'status: pr-in-progress';
+      } else {
+        // Check if it has approvals
+        const reviewsJson = execSync(
+          `gh pr view ${pr.number} --json reviews`,
+          { encoding: "utf8" }
+        );
+        const { reviews } = JSON.parse(reviewsJson);
+        const hasApproval = reviews.some(r => r.state === 'APPROVED');
+
+        if (hasApproval) {
+          newStatus = 'status: code-review-complete';
+        } else {
+          newStatus = 'status: in-code-review';
+        }
+      }
+
+      console.log(`  Adding label: ${newStatus}`);
+      execSync(`gh pr edit ${pr.number} --add-label "${newStatus}"`, { stdio: 'pipe' });
+
+      console.log(`  ✅ Fixed PR #${pr.number}`);
+    }
+
+    console.log("\n✅ All PRs have been updated!");
+    console.log("\nThe sync-labels-to-project workflow will now sync these labels to the project fields.");
+
+  } catch (error) {
+    console.error("❌ Error:", error.message);
+    process.exit(1);
+  }
+}
+
+fixPRProjectStatus();


### PR DESCRIPTION
Quick fix for the failing workflows that are blocking PR #39 and other PRs.

## Problem
- add-to-project workflow was looking for a user project instead of the repository project
- sync-labels-to-project was using 'issue' GraphQL field for PRs, which doesn't work

## Solution
- Hardcoded the project ID for now (can be made configurable later)
- Fixed GraphQL query to use 'pullRequest' for PRs and 'issue' for issues
- Fixed variable name in GraphQL query

This should unblock PR #39 and allow us to merge it.